### PR TITLE
fix: scope KMS decrypt to specific SSM parameters via encryption context

### DIFF
--- a/datadog/samples/travel-concierge-agent-observability/infrastructure/mcp-servers/lib/base-mcp-stack.ts
+++ b/datadog/samples/travel-concierge-agent-observability/infrastructure/mcp-servers/lib/base-mcp-stack.ts
@@ -81,7 +81,8 @@ export abstract class BaseMcpStack extends cdk.Stack {
         )
       }));
 
-      // Add KMS decrypt permission for SecureString parameters
+      // Add KMS decrypt permission for SecureString parameters, scoped to the
+      // specific parameter ARNs via SSM's PARAMETER_ARN encryption context.
       this.role.addToPolicy(new iam.PolicyStatement({
         sid: 'KMSDecrypt',
         effect: iam.Effect.ALLOW,
@@ -89,7 +90,10 @@ export abstract class BaseMcpStack extends cdk.Stack {
         resources: [`arn:aws:kms:${this.region}:${this.account}:key/*`],
         conditions: {
           StringEquals: {
-            'kms:ViaService': `ssm.${this.region}.amazonaws.com`
+            'kms:ViaService': `ssm.${this.region}.amazonaws.com`,
+            'kms:EncryptionContext:PARAMETER_ARN': props.ssmParameters.map(param =>
+              `arn:aws:ssm:${this.region}:${this.account}:parameter${param}`
+            )
           }
         }
       }));


### PR DESCRIPTION
## Summary
- Tighten the `KMSDecrypt` policy in `BaseMcpStack` to least privilege.
- Previously: `kms:Decrypt` against every key in the account/region, gated only by `kms:ViaService=ssm.<region>.amazonaws.com`.
- Now: adds `kms:EncryptionContext:PARAMETER_ARN` matching the same `props.ssmParameters` ARNs the SSM read policy already scopes to, so the role can only decrypt the SecureStrings this stack actually reads.

## File changed
- `datadog/samples/travel-concierge-agent-observability/infrastructure/mcp-servers/lib/base-mcp-stack.ts` (+6, −2)

## Test plan
- [ ] `npx tsc --noEmit` from `infrastructure/mcp-servers/` (passes locally)
- [ ] `cdk synth` to confirm the synthesized policy contains both `kms:ViaService` and `kms:EncryptionContext:PARAMETER_ARN` conditions
- [ ] Deploy and confirm SSM SecureString fetches still succeed at runtime